### PR TITLE
Update naming for Voltaic Benchmarks

### DIFF
--- a/benches/Voltaic Click Benchmarks.json
+++ b/benches/Voltaic Click Benchmarks.json
@@ -1,5 +1,5 @@
 {
-	"playlistName": "VOLTAIC OPEN BENCHMARKS CLICKING",
+	"playlistName": "Voltaic Click Benchmarks",
 	"scenarioList": [
 		{
 			"scenarioName": "Pasu Voltaic",
@@ -22,5 +22,5 @@
 			"playCount": 1
 		}
 	],
-	"isFavorite": true
+	"isFavorite": false
 }

--- a/benches/Voltaic Click Easy Benchmarks.json
+++ b/benches/Voltaic Click Easy Benchmarks.json
@@ -1,5 +1,5 @@
 {
-	"playlistName": "VOLTAIC OPEN BENCHMARKS CLICKING EASY",
+	"playlistName": "Voltaic Click Easy Banchmarks",
 	"scenarioList": [
 		{
 			"scenarioName": "Pasu Voltaic Easy",
@@ -26,5 +26,5 @@
 			"playCount": 5
 		}
 	],
-	"isFavorite": true
+	"isFavorite": false
 }

--- a/benches/Voltaic Switching Benchmarks.json
+++ b/benches/Voltaic Switching Benchmarks.json
@@ -1,5 +1,5 @@
 {
-	"playlistName": "Voltaic Switching Benchmarks.json",
+	"playlistName": "Voltaic Switching Benchmarks",
 	"scenarioList": [
 		{
 			"scenarioName": "patTS Voltaic",

--- a/benches/Voltaic Switching Benchmarks.json
+++ b/benches/Voltaic Switching Benchmarks.json
@@ -1,5 +1,5 @@
 {
-	"playlistName": "VOLTAIC OPEN BENCHMARKS SWITCHING",
+	"playlistName": "Voltaic Switching Benchmarks.json",
 	"scenarioList": [
 		{
 			"scenarioName": "patTS Voltaic",
@@ -26,5 +26,5 @@
 			"playCount": 1
 		}
 	],
-	"isFavorite": true
+	"isFavorite": false
 }

--- a/benches/Voltaic Switching Easy Benchmarks.json
+++ b/benches/Voltaic Switching Easy Benchmarks.json
@@ -26,5 +26,5 @@
 			"playCount": 10
 		}
 	],
-	"isFavorite": true
+	"isFavorite": false
 }

--- a/benches/Voltaic Switching Easy Benchmarks.json
+++ b/benches/Voltaic Switching Easy Benchmarks.json
@@ -1,5 +1,5 @@
 {
-	"playlistName": "VOLTAIC OPEN BENCHMARKS SWITCHING EASY",
+	"playlistName": "Voltaic Switching Easy Benchmarks",
 	"scenarioList": [
 		{
 			"scenarioName": "patTS Voltaic Easy",

--- a/benches/Voltaic Tracking Benchmarks.json
+++ b/benches/Voltaic Tracking Benchmarks.json
@@ -1,5 +1,5 @@
 {
-	"playlistName": "VOLTAIC OPEN BENCHMARKS TRACKING ",
+	"playlistName": "Voltaic Tracking Benchmarks",
 	"scenarioList": [
 		{
 			"scenarioName": "Smoothbot Voltaic",
@@ -26,5 +26,5 @@
 			"playCount": 1
 		}
 	],
-	"isFavorite": true
+	"isFavorite": false
 }

--- a/benches/Voltaic Tracking Easy Benchmarks.json
+++ b/benches/Voltaic Tracking Easy Benchmarks.json
@@ -1,5 +1,5 @@
 {
-	"playlistName": "VOLTAIC OPEN BENCHMARKS TRACKING EASY",
+	"playlistName": "Voltaic Tracking Easy Benchmarks",
 	"scenarioList": [
 		{
 			"scenarioName": "Smoothbot Voltaic Easy",
@@ -26,5 +26,5 @@
 			"playCount": 3
 		}
 	],
-	"isFavorite": true
+	"isFavorite": false
 }


### PR DESCRIPTION
Hi, firstly thanks for creating this repo alongside your YouTube vids. They helped me a lot.

I have renamed the voltaic benchmarks. The previous names were in uppercase and a bit too long to always see in Kovaaks. I have also set `isFavourite` to false by default.

Happy to make any further changes.

Cheers
